### PR TITLE
Improve pylint score

### DIFF
--- a/Server/Driving/dynamixels.py
+++ b/Server/Driving/dynamixels.py
@@ -114,7 +114,8 @@ class Dynamixel:
                         protocol_handler.write4ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
                                 self.query(name, 'Address'), value)
                 except TERMIOS_ERROR as err:
-                    print('An error occured when reading from Dynamixel {}'.format(self.dynamixel_id))
+                    print('An error occured when reading from Dynamixel {}'\
+                        .format(self.dynamixel_id))
                     print('Make sure the U2D2 is connected properly!')
                     print('Debug info:\n', err)
             else:

--- a/Server/Driving/dynamixels.py
+++ b/Server/Driving/dynamixels.py
@@ -7,6 +7,7 @@ Contains:
     - A class (Dynamixel) with functions to interface with the DynamixelSDK
 """
 import os
+from termios import error as TERMIOS_ERROR
 from dynamixel_sdk import PortHandler, PacketHandler
 
 PORT_HANDLER = None
@@ -112,8 +113,8 @@ class Dynamixel:
                     elif size == 4:
                         protocol_handler.write4ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
                                 self.query(name, 'Address'), value)
-                except Exception as err:
-                    print('An error occured when writing to Dynamixel {}'.format(self.dynamixel_id))
+                except TERMIOS_ERROR as err:
+                    print('An error occured when reading from Dynamixel {}'.format(self.dynamixel_id))
                     print('Make sure the U2D2 is connected properly!')
                     print('Debug info:\n', err)
             else:
@@ -140,7 +141,7 @@ class Dynamixel:
                              self.query(name, 'Address'))[0])
                     return str(PROTOCOL_TWO.read1ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
                             self.query(name, 'Address')))
-                except Exception as err:
+                except TERMIOS_ERROR as err:
                     print('An error occured when reading from Dynamixel {}'\
                         .format(self.dynamixel_id))
                     print('Make sure the U2D2 is connected properly!')

--- a/Server/Driving/dynamixels.py
+++ b/Server/Driving/dynamixels.py
@@ -98,28 +98,20 @@ class Dynamixel:
         if name in self.control_table:
             if 'W' in self.query(name, 'Access'):
                 size = self.query(name, 'Size(Byte)')
+                if self.protocol == 1:
+                    protocol_handler = PROTOCOL_ONE
+                else:
+                    protocol_handler = PROTOCOL_TWO
                 try:
                     if size == 1:
-                        if self.protocol == 1:
-                            PROTOCOL_ONE.write1ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
-                                 self.query(name, 'Address'), value)
-                        else:
-                            PROTOCOL_TWO.write1ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
-                                 self.query(name, 'Address'), value)
+                        protocol_handler.write1ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
+                                self.query(name, 'Address'), value)
                     elif size == 2:
-                        if self.protocol == 1:
-                            PROTOCOL_ONE.write2ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
-                                 self.query(name, 'Address'), value)
-                        else:
-                            PROTOCOL_TWO.write2ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
-                                 self.query(name, 'Address'), value)
+                        protocol_handler.write2ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
+                                self.query(name, 'Address'), value)
                     elif size == 4:
-                        if self.protocol == 1:
-                            PROTOCOL_ONE.write4ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
-                                 self.query(name, 'Address'), value)
-                        else:
-                            PROTOCOL_TWO.write4ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
-                                 self.query(name, 'Address'), value)
+                        protocol_handler.write4ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
+                                self.query(name, 'Address'), value)
                 except Exception as err:
                     print('An error occured when writing to Dynamixel {}'.format(self.dynamixel_id))
                     print('Make sure the U2D2 is connected properly!')

--- a/Server/Driving/dynamixels.py
+++ b/Server/Driving/dynamixels.py
@@ -1,225 +1,255 @@
+"""This module assists in the connection between a Python script to\
+    a U2D2, which, in turn connects to Dynamixels running either protocol\
+        1 or protocol 2.
+Contains:
+    - Code to automatically connect to a U2D2 assigned under /dev/ttyUSB
+    - Code that adjusts the baudrate of the U2D2
+    - A class (Dynamixel) with functions to interface with the DynamixelSDK
+"""
 import os
 from dynamixel_sdk import PortHandler, PacketHandler
 
-port_handler = None
+PORT_HANDLER = None
 
 # Try to connect to the U2D2
-for i in range(2):
-  path = '/dev/ttyUSB{}'.format(i)
-  if os.path.exists(path):
-    port_handler = PortHandler(path)
-    print('Initialised U2D2 at {}'.format(path))
-    break
-  else:
-    print('Could not initialise U2D2 at {}'.format(path))
+for port in range(2):
+    path = '/dev/ttyUSB{}'.format(port)
+    if os.path.exists(path):
+        PORT_HANDLER = PortHandler(path)
+        print('Initialised U2D2 at {}'.format(path))
+        break
+    else:
+        print('Could not initialise U2D2 at {}'.format(path))
 
 # Could not find a USB device in range
-if port_handler == None:
-  print('Could not initialise U2D2! Maybe increase port range?')
-  exit()
+if PORT_HANDLER is None:
+    print('Could not initialise U2D2! Maybe increase port range?')
+    exit()
 
 # Protocol 1 packet handler:
-p1 = PacketHandler(1.0)
+PROTOCOL_ONE = PacketHandler(1.0)
 # Protocol 2 packet handler:
-p2 = PacketHandler(2.0)
+PROTOCOL_TWO = PacketHandler(2.0)
 
-if port_handler.openPort():
-  pass
+if PORT_HANDLER.openPort():
+    pass
 else:
-  print("Failed to open the port")
+    print("Failed to open the port")
 
-if port_handler.setBaudRate(1000000):
-  pass
+if PORT_HANDLER.setBaudRate(1000000):
+    pass
 else:
-  print("Failed to change the baudrate")
+    print("Failed to change the baudrate")
 
 class Dynamixel:
-  """
-  An object representing a single Dynamixel
-
-  The Dynamixel class contains the ability to read or write to any address
-  in its control table, which is specified as a CSV file interpreted through
-  the GUI.
-
-  Attributes:
-    name: The name of the CSV containing the relevant control table
-    ID: The initial ID of the Dynamixel
-    protocol: The protocol version of the servo - either 1 or 2
-    control_table: A dictionary containing the control table, formatted as
-      control_table[data name] = {Address, size etc}. This is generated
-      by the initialise_dynamixel function
-  """
-
-  def __init__(self, name, ID, protocol, control_table):
     """
-    Initialises the Dynamixel class with model, ID, protocol and control table
+    An object representing a single Dynamixel
+
+    The Dynamixel class contains the ability to read or write to any address
+    in its control table, which is specified as a CSV file interpreted through
+    the GUI.
+
+    Attributes:
+        name: The name of the CSV containing the relevant control table
+        dynamixel_id: The initial ID of the Dynamixel
+        protocol: The protocol version of the servo - either 1 or 2
+        control_table: A dictionary containing the control table, formatted as
+            control_table[data name] = {Address, size etc}. This is generated
+            by the initialise_dynamixel function
     """
 
-    self.name = name
-    self.ID = ID
-    self.protocol = protocol
-    self.control_table = control_table
-    self.is_joint = True
-    self.is_wheel = False
+    def __init__(self, name, dynamixel_id, protocol, control_table):
+        """
+        Initialises the Dynamixel class with model, ID, protocol and control table
+        """
 
-  def query(self, item, detail):
-    """
-    Returns the value of the row (item) and column (detail)
+        self.name = name
+        self.dynamixel_id = dynamixel_id
+        self.protocol = protocol
+        self.control_table = control_table
+        self.is_joint = True
+        self.is_wheel = False
 
-    Args:
-      item: The row in which to look in for the information
-      detail: The column in which to look in for the information
+    def query(self, item, detail):
+        """
+        Returns the value of the row (item) and column (detail)
 
-    Returns:
-      The data found at row (item) and column (detail)
-    """
-    try:
-      return self.control_table[item][detail]
-    except KeyError:
-      print('Could not find a matching address!')
+        Args:
+            item: The row in which to look in for the information
+            detail: The column in which to look in for the information
 
-  def write_value(self, name, value):
-    """
-    Writes value to the address of name
-
-    Args:
-      name: The name of the data in the control table
-      value: The value to write to the Dynamixel
-    """
-
-    if name in self.control_table:
-      if 'W' in self.query(name, 'Access'):
-        size = self.query(name, 'Size(Byte)')
+        Returns:
+            The data found at row (item) and column (detail)
+        """
         try:
-          if size == 1:
-            if self.protocol == 1:
-              p1.write1ByteTxRx(port_handler, self.ID, self.query(name, 'Address'), value)
-            else:
-              p2.write1ByteTxRx(port_handler, self.ID, self.query(name, 'Address'), value)
-          elif size == 2:
-            if self.protocol == 1:
-              p1.write2ByteTxRx(port_handler, self.ID, self.query(name, 'Address'), value)
-            else:
-              p2.write2ByteTxRx(port_handler, self.ID, self.query(name, 'Address'), value)
-          elif size == 4:
-            if self.protocol == 1:
-              p1.write4ByteTxRx(port_handler, self.ID, self.query(name, 'Address'), value)
-            else:
-              p2.write4ByteTxRx(port_handler, self.ID, self.query(name, 'Address'), value)
-        except Exception as err:
-          print('An error occured when writing to Dynamixel {}'.format(self.ID))
-          print('Make sure the U2D2 is connected properly!')
-          print('Debug info:\n', err)
-      else:
-        print('Cannot write to read-only address!')
-    else:
-      print('Cannot find table value!')
+            return self.control_table[item][detail]
+        except KeyError:
+            print('Could not find a matching address!')
 
-  def read_value(self, name):
+    def write_value(self, name, value):
+        """
+        Writes value to the address of name
+
+        Args:
+            name: The name of the data in the control table
+            value: The value to write to the Dynamixel
+        """
+
+        if name in self.control_table:
+            if 'W' in self.query(name, 'Access'):
+                size = self.query(name, 'Size(Byte)')
+                try:
+                    if size == 1:
+                        if self.protocol == 1:
+                            PROTOCOL_ONE.write1ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
+                                 self.query(name, 'Address'), value)
+                        else:
+                            PROTOCOL_TWO.write1ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
+                                 self.query(name, 'Address'), value)
+                    elif size == 2:
+                        if self.protocol == 1:
+                            PROTOCOL_ONE.write2ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
+                                 self.query(name, 'Address'), value)
+                        else:
+                            PROTOCOL_TWO.write2ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
+                                 self.query(name, 'Address'), value)
+                    elif size == 4:
+                        if self.protocol == 1:
+                            PROTOCOL_ONE.write4ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
+                                 self.query(name, 'Address'), value)
+                        else:
+                            PROTOCOL_TWO.write4ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
+                                 self.query(name, 'Address'), value)
+                except Exception as err:
+                    print('An error occured when writing to Dynamixel {}'.format(self.dynamixel_id))
+                    print('Make sure the U2D2 is connected properly!')
+                    print('Debug info:\n', err)
+            else:
+                print('Cannot write to read-only address!')
+        else:
+            print('Cannot find table value!')
+
+    def read_value(self, name):
+        """
+        Reads a value at the address of name
+
+        Args:
+            name: The name of the value to read
+
+        Returns:
+            The value at the address of name
+        """
+
+        if name in self.control_table:
+            if 'R' in self.query(name, 'Access'):
+                try:
+                    if self.protocol == 1:
+                        return str(PROTOCOL_ONE.read1ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
+                             self.query(name, 'Address'))[0])
+                    return str(PROTOCOL_TWO.read1ByteTxRx(PORT_HANDLER, self.dynamixel_id,\
+                            self.query(name, 'Address')))
+                except Exception as err:
+                    print('An error occured when reading from Dynamixel {}'\
+                        .format(self.dynamixel_id))
+                    print('Make sure the U2D2 is connected properly!')
+                    print('Debug info:\n', err)
+            else:
+                print('Cannot read at address!')
+        else:
+            print('Cannot find table value!')
+        return None
+
+    def reset_value(self, name):
+        """
+        Resets a value to its default
+
+        Args:
+            name: The name of the value to reset
+        """
+
+        if name in self.control_table:
+            self.write_value(name, self.control_table[name]['InitialValue'])
+
+    def wheel_mode(self):
+        """
+        Places the dynamixel in 'wheel mode', moving using speed only
+        """
+
+        self.write_value('Torque Enable', 0)
+        self.write_value('CW Angle Limit', 0)
+        self.write_value('CCW Angle Limit', 0)
+        self.write_value('Torque Enable', 1)
+        self.is_wheel = True
+        self.is_joint = False
+
+    def joint_mode(self):
+        """
+        Places the dynamixel in 'joint mode', moving using speed and goal position
+        """
+
+        self.write_value('Torque Enable', 0)
+        self.reset_value('CW Angle Limit')
+        self.reset_value('CCW Angle Limit')
+        self.write_value('Torque Enable', 1)
+        self.is_joint = True
+        self.is_wheel = False
+
+    def restart(self):
+        """
+        Resets the values of all writeable items in the control table
+        """
+
+        self.write_value('Torque Enable', 0)
+        for value in self.control_table:
+            self.reset_value(value)
+        self.is_wheel = False
+        self.is_joint = False
+
+def find_file(filename):
     """
-    Reads a value at the address of name
+    Finds a file in the Servos/ directory
 
     Args:
-      name: The name of the value to read
-    
-    Returns:
-      The value at the address of name
+        filename: The name of the file to find
     """
-
-    if name in self.control_table:
-      if 'R' in self.query(name, 'Access'):
-        try:
-          size = self.query(name, 'Size(Byte)')
-          if self.protocol == 1:
-            return str(p1.read1ByteTxRx(port_handler, self.ID, self.query(name, 'Address'))[0])
-          else:
-            return str(p2.read1ByteTxRx(port_handler, self.ID, self.query(name, 'Address')))
-        except Exception as err:
-          print('An error occured when reading from Dynamixel {}'.format(self.ID))
-          print('Make sure the U2D2 is connected properly!')
-          print('Debug info:\n', err)
-      else:
-        print('Cannot read at address!')
-    else:
-      print('Cannot find table value!')
-  
-  def reset_value(self, name):
-    """
-    Resets a value to its default
-
-    Args:
-      name: The name of the value to reset
-    """
-
-    if name in self.control_table:
-      self.write_value(name, self.control_table[name]['InitialValue'])
-      
-  def wheel_mode(self):
-    """
-    Places the dynamixel in 'wheel mode', moving using speed only
-    """
-
-    self.write_value('Torque Enable', 0)
-    self.write_value('CW Angle Limit', 0)
-    self.write_value('CCW Angle Limit', 0)
-    self.write_value('Torque Enable', 1)
-    self.is_wheel = True
-    self.is_joint = False
-
-  def joint_mode(self):
-    """
-    Places the dynamixel in 'joint mode', moving using speed and goal position
-    """
-
-    self.write_value('Torque Enable', 0)
-    self.reset_value('CW Angle Limit')
-    self.reset_value('CCW Angle Limit')
-    self.write_value('Torque Enable', 1)
-    self.is_joint = True
-    self.is_wheel = False
-
-  def restart(self):
-    """
-    Resets the values of all writeable items in the control table
-    """
-
-    self.write_value('Torque Enable', 0)
-    for i in self.control_table:
-      self.reset_value(i)
-    self.is_wheel = False
-    self.is_joint = False
-
-def initialise_dynamixel(model, ID, protocol):
-  """
-  Creates a Dynamixel object with a relevant control table
-
-  Args:
-    model: The model name of the servo, used to find the CSV control table
-    ID: The initial ID of the Dynamixel
-    protocol: The protocol used by the Dynamixel, either 1 or 2
-
-  Returns:
-    A Dynamixel class containing the control table found from the CSV, as well
-    as the ID and protocol specified in its arguments
-  """
-
-  for root, _, files in os.walk("Servos/", topdown=False):
-    for name in files:
-      if os.path.splitext(name)[0] == model:
-        path = os.path.join(root, name)
-        table = open(path, 'r').readlines()
-        first_line = table[0].split(', ')
-        control_table = {}
-        for i in range(1, len(table)):
-          line = table[i].split(', ')
-          build = {}
-          build[line[2]] = {}
-          for item in range(len(line)):
-            if line[item] != line[2]:
-              new = line[item].strip()
-              if new.isdigit():
-                new = int(new)
-              build[line[2]][first_line[item].strip()] = new
-          control_table = {**control_table, **build}
-        return Dynamixel(os.path.splitext(name)[0], ID, protocol, control_table)
+    for root, _, files in os.walk("Servos/", topdown=False):
+        for name in files:
+            if os.path.splitext(name)[0] == filename:
+                filepath = os.path.join(root, name)
+                return filepath
     print('Could not find matching control table!')
+    return None
+
+def initialise_dynamixel(model, dynamixel_id, protocol):
+    """
+    Creates a Dynamixel object with a relevant control table
+
+    Args:
+        model: The model name of the servo, used to find the CSV control table
+        dynamixel_id: The initial ID of the Dynamixel
+        protocol: The protocol used by the Dynamixel, either 1 or 2
+
+    Returns:
+        A Dynamixel class containing the control table found from the CSV, as well
+        as the ID and protocol specified in its arguments
+    """
+
+    filepath = find_file(model)
+    if filepath is None:
+        return Dynamixel(None, None, None, None)
+
+    table = open(filepath, 'r').readlines()
+    first_line = table[0].split(', ')
+    control_table = {}
+    for row in range(1, len(table)):
+        line = table[row].split(', ')
+        build = {}
+        build[line[2]] = {}
+        for iterator, item in enumerate(line):
+            if line[iterator] != line[2]:
+                new = item.strip()
+                if new.isdigit():
+                    new = int(new)
+                build[line[2]][first_line[iterator].strip()] = new
+        control_table = {**control_table, **build}
+    return Dynamixel(model, dynamixel_id, protocol, control_table)

--- a/Server/Driving/server.py
+++ b/Server/Driving/server.py
@@ -16,47 +16,53 @@ REGEX = r"\((init|delete|modify|mode|read)\)"
 class UDPHandler(socketserver.BaseRequestHandler):
     """The UDP handler class implementing functions from dynamixels.py
     """
+    def handle_regex(self, data):
+        """Handles the 'special' commands encased in brackets
+        Args:
+            data: The data to be parsed
+        """
+        # Fancy regular expression to check if server is sending other commands
+        # WARNING: This code is VERY experimental and will crash if
+        # The wrong input is given
+
+        items = data.split('-')
+        cmd = re.match(REGEX, items[0]).group(1)
+        if cmd == "init":
+            model = items[1]
+            dynamixel_id, protocol = map(int, items[2:])
+            SERVOS[dynamixel_id] = initialise_dynamixel(model, dynamixel_id, protocol)
+            SERVOS[dynamixel_id].joint_mode()
+        elif cmd == "modify":
+            dynamixel_id, item, value = map(str, items[1:])
+            dynamixel_id = int(dynamixel_id)
+            value = int(value)
+            if dynamixel_id in SERVOS:
+                SERVOS[dynamixel_id].write_value(item, value)
+        elif cmd == "read":
+            dynamixel_id, item = map(str, items[1:])
+            dynamixel_id = int(dynamixel_id)
+            if dynamixel_id in SERVOS:
+                msg = "{}:{}".format(item, SERVOS[dynamixel_id].read_value(item))
+                msg = bytes(msg, 'utf-8')
+                SOCK.sendto(msg, (str(self.client_address[0]), 5003))
+        elif cmd == "mode":
+            dynamixel_id, mode = map(str, items[1:])
+            dynamixel_id = int(dynamixel_id)
+            if dynamixel_id in SERVOS:
+                if mode == 'wheel':
+                    SERVOS[dynamixel_id].wheel_mode()
+                elif mode == 'joint':
+                    SERVOS[dynamixel_id].joint_mode()
+        elif cmd == 'delete':
+            dynamixel_id = int(items[1])
+            if dynamixel_id in SERVOS:
+                SERVOS.pop(dynamixel_id)
     def handle(self):
         self.data = self.request[0].decode('utf-8').strip()
         new = self.data.split('\n')
         for i in new:
             if len(re.findall(REGEX, i)) == 1:
-                # Fancy regular expression to check if server is sending other commands
-                # WARNING: This code is VERY experimental and will crash if
-                # The wrong input is given
-
-                items = i.split('-')
-                cmd = re.match(REGEX, items[0]).group(1)
-                if cmd == "init":
-                    model = items[1]
-                    dynamixel_id, protocol = map(int, items[2:])
-                    SERVOS[dynamixel_id] = initialise_dynamixel(model, dynamixel_id, protocol)
-                    SERVOS[dynamixel_id].joint_mode()
-                elif cmd == "modify":
-                    dynamixel_id, item, value = map(str, items[1:])
-                    dynamixel_id = int(dynamixel_id)
-                    value = int(value)
-                    if dynamixel_id in SERVOS:
-                        SERVOS[dynamixel_id].write_value(item, value)
-                elif cmd == "read":
-                    dynamixel_id, item = map(str, items[1:])
-                    dynamixel_id = int(dynamixel_id)
-                    if dynamixel_id in SERVOS:
-                        msg = "{}:{}".format(item, SERVOS[dynamixel_id].read_value(item))
-                        msg = bytes(msg, 'utf-8')
-                        SOCK.sendto(msg, (str(self.client_address[0]), 5003))
-                elif cmd == "mode":
-                    dynamixel_id, mode = map(str, items[1:])
-                    dynamixel_id = int(dynamixel_id)
-                    if dynamixel_id in SERVOS:
-                        if mode == 'wheel':
-                            SERVOS[dynamixel_id].wheel_mode()
-                        elif mode == 'joint':
-                            SERVOS[dynamixel_id].joint_mode()
-                elif cmd == 'delete':
-                    dynamixel_id = int(items[1])
-                    if dynamixel_id in SERVOS:
-                        SERVOS.pop(dynamixel_id)
+                self.handle_regex(i)
             elif i.count('-') == 1:
                 # Wheel
                 dynamixel_id, speed = map(int, i.split('-'))

--- a/Server/Driving/server.py
+++ b/Server/Driving/server.py
@@ -1,80 +1,86 @@
+"""This script is used for implementing commands defined in dynamixels.py
+Contains:
+    - A UDP Server class that handles requests
+"""
 import socketserver
 import socket
 import re
-from dynamixels import Dynamixel, initialise_dynamixel
+from dynamixels import initialise_dynamixel
 
-sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+SOCK = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-servos = {}
-regex = r"\((init|delete|modify|mode|read)\)"
-# servos[12] = initialise_dynamixel('xl320', 12, 2)
+SERVOS = {}
+REGEX = r"\((init|delete|modify|mode|read)\)"
+# SERVOS[12] = initialise_dynamixel('xl320', 12, 2)
 
 class UDPHandler(socketserver.BaseRequestHandler):
-  def handle(self):
-    self.data = self.request[0].decode('utf-8').strip()
-    new = self.data.split('\n')
-    for i in new:
-      if len(re.findall(regex, i)) == 1:
-        # Fancy regular expression to check if server is sending other commands
-        # WARNING: This code is VERY experimental and will crash if
-        # The wrong input is given
+    """The UDP handler class implementing functions from dynamixels.py
+    """
+    def handle(self):
+        self.data = self.request[0].decode('utf-8').strip()
+        new = self.data.split('\n')
+        for i in new:
+            if len(re.findall(REGEX, i)) == 1:
+                # Fancy regular expression to check if server is sending other commands
+                # WARNING: This code is VERY experimental and will crash if
+                # The wrong input is given
 
-        items = i.split('-')
-        cmd = re.match(regex, items[0]).group(1)
-        if cmd == "init":
-          model = items[1]
-          ID, protocol = map(int, items[2:])
-          servos[ID] = initialise_dynamixel(model, ID, protocol)
-          servos[ID].joint_mode()
-        elif cmd == "modify":
-          ID, item, value = map(str, items[1:])
-          ID = int(ID)
-          value = int(value)
-          if ID in servos:
-            servos[ID].write_value(item, value)
-        elif cmd == "read":
-          ID, item = map(str, items[1:])
-          ID = int(ID)
-          if ID in servos:
-            msg = "{}:{}".format(item, servos[ID].read_value(item))
-            msg = bytes(msg, 'utf-8')
-            sock.sendto(msg, (str(self.client_address[0]), 5003))
-        elif cmd == "mode":
-          ID, mode = map(str, items[1:])
-          ID = int(ID)
-          if ID in servos:
-            if mode == 'wheel':
-              servos[ID].wheel_mode()
-            elif mode == 'joint':
-              servos[ID].joint_mode()
-        elif cmd == 'delete':
-          ID = int(items[1])
-          if ID in servos:
-            servos.pop(ID)
-      elif i.count('-') == 1:
-        # Wheel
-        ID, speed = map(int, i.split('-'))
-        if ID in servos and servos[ID].is_wheel:
-          servos[ID].write_value('Moving Speed', speed)
-        elif ID not in servos:
-          print('There is no servo of ID {} initialised!'.format(ID))
-        else:
-          print('Servo {} is not a wheel!'.format(ID))
-      elif i.count('-') == 2:
-        # Joint
-        ID, pos, speed = map(int, i.split('-'))
-        if ID in servos and servos[ID].is_joint:
-          servos[ID].write_value('Goal Position', pos)
-          servos[ID].write_value('Moving Speed', speed)
-        elif ID not in servos:
-          print('There is no servo of ID {} initialised!'.format(ID))
-        else:
-          print('Servo {} is not a joint!'.format(ID))
-      else:
-        print('Invalid command! {}'.format(i))
+                items = i.split('-')
+                cmd = re.match(REGEX, items[0]).group(1)
+                if cmd == "init":
+                    model = items[1]
+                    dynamixel_id, protocol = map(int, items[2:])
+                    SERVOS[dynamixel_id] = initialise_dynamixel(model, dynamixel_id, protocol)
+                    SERVOS[dynamixel_id].joint_mode()
+                elif cmd == "modify":
+                    dynamixel_id, item, value = map(str, items[1:])
+                    dynamixel_id = int(dynamixel_id)
+                    value = int(value)
+                    if dynamixel_id in SERVOS:
+                        SERVOS[dynamixel_id].write_value(item, value)
+                elif cmd == "read":
+                    dynamixel_id, item = map(str, items[1:])
+                    dynamixel_id = int(dynamixel_id)
+                    if dynamixel_id in SERVOS:
+                        msg = "{}:{}".format(item, SERVOS[dynamixel_id].read_value(item))
+                        msg = bytes(msg, 'utf-8')
+                        SOCK.sendto(msg, (str(self.client_address[0]), 5003))
+                elif cmd == "mode":
+                    dynamixel_id, mode = map(str, items[1:])
+                    dynamixel_id = int(dynamixel_id)
+                    if dynamixel_id in SERVOS:
+                        if mode == 'wheel':
+                            SERVOS[dynamixel_id].wheel_mode()
+                        elif mode == 'joint':
+                            SERVOS[dynamixel_id].joint_mode()
+                elif cmd == 'delete':
+                    dynamixel_id = int(items[1])
+                    if dynamixel_id in SERVOS:
+                        SERVOS.pop(dynamixel_id)
+            elif i.count('-') == 1:
+                # Wheel
+                dynamixel_id, speed = map(int, i.split('-'))
+                if dynamixel_id in SERVOS and SERVOS[dynamixel_id].is_wheel:
+                    SERVOS[dynamixel_id].write_value('Moving Speed', speed)
+                elif dynamixel_id not in SERVOS:
+                    print('There is no servo of dynamixel_id {} initialised!'.format(dynamixel_id))
+                else:
+                    print('Servo {} is not a wheel!'.format(dynamixel_id))
+            elif i.count('-') == 2:
+                # Joint
+                dynamixel_id, pos, speed = map(int, i.split('-'))
+                if dynamixel_id in SERVOS and SERVOS[dynamixel_id].is_joint:
+                    SERVOS[dynamixel_id].write_value('Goal Position', pos)
+                    SERVOS[dynamixel_id].write_value('Moving Speed', speed)
+                elif dynamixel_id not in SERVOS:
+                    print('There is no servo of dynamixel_id {} initialised!'.format(dynamixel_id))
+                else:
+                    print('Servo {} is not a joint!'.format(dynamixel_id))
+            else:
+                print('Invalid command! {}'.format(i))
 
 socketserver.UDPServer.allow_reuse_address = True
-server = socketserver.UDPServer(("", 5001), UDPHandler)
+SERVER = socketserver.UDPServer(("", 5001), UDPHandler)
 
 print('Dynamixel Server Started!')
-server.serve_forever()
+SERVER.serve_forever()


### PR DESCRIPTION
The refactored python driving sever code (`dynamixels.py` & `server,py`), although technologically superior to the old code, is hard to read and does not conform to the styleguide, which goes against one of the main objectives of this year's redesign - to make the code more advanced but easier to read.

The commits introduced in this pull request update the `Pylint` 'score'/rating to fully conform to its styleguide, with `dynamixels.py` and `server.py` both scoring 10/10 from the linter.