### PR TITLE
Update data_index in dynamixels.py

### DIFF
--- a/Server/Driving/dynamixels.py
+++ b/Server/Driving/dynamixels.py
@@ -234,16 +234,17 @@ def initialise_dynamixel(model, dynamixel_id, protocol):
 
     table = open(filepath, 'r').readlines()
     first_line = table[0].split(', ')
+    data_index = first_line.index('Data Name')
     control_table = {}
     for row in range(1, len(table)):
         line = table[row].split(', ')
         build = {}
-        build[line[2]] = {}
+        build[line[data_index]] = {}
         for iterator, item in enumerate(line):
-            if line[iterator] != line[2]:
+            if line[iterator] != line[data_index]:
                 new = item.strip()
                 if new.isdigit():
                     new = int(new)
-                build[line[2]][first_line[iterator].strip()] = new
+                build[line[data_index]][first_line[iterator].strip()] = new
         control_table = {**control_table, **build}
     return Dynamixel(model, dynamixel_id, protocol, control_table)


### PR DESCRIPTION
# Changes
* Create data_index variable to point to the index of 'Data Name' table header
* Use the data_index value on subsequent build lines

# Reason for this change
Previously, the data index is hardcoded to be 2. This will cause an error when the 'Data Index' in the actual csv file is located in any index other than 2. This change enable data_index variable to detect the 'Data Index' position correctly.

# Checklist
* I have talked to someone about making this change [Y]
* This change has been tested or has been approved by a senior member [N]
