### PR TITLE
Controller creator

### DIFF
--- a/src/create/controller/controller.html
+++ b/src/create/controller/controller.html
@@ -8,6 +8,6 @@
   <script src='controller.js'></script>
 </head>
 <body>
-  
+  <div id="controllers"></div>
 </body>
 </html>

--- a/src/create/controller/controller.js
+++ b/src/create/controller/controller.js
@@ -181,6 +181,9 @@ function renameNode(oldName, newName, index) {
   controllers[index].updateNodes();
 
   document.getElementById(`${index}-${oldName}`).id = `${index}-${newName}`;
+  const input = document.getElementById(`${index}-${oldName}-input`);
+  input.id = newName;
+  input.value = newName;
 }
 
 /**
@@ -208,6 +211,41 @@ function generateConfig(index) {
   }
 
   return config;
+}
+
+/**
+ * Loads a compatible controller for editing
+ * @param {String} name The name of the controller file
+ */
+function loadController(name) {
+  const path = `./src/conf/Controllers/${name}.json`;
+  fs.readFile(path, (err, data) => {
+    if (err) {
+      console.error('Error reading config file:');
+      console.error(err);
+    } else {
+      const config = JSON.parse(data);
+      const index = config.index;
+      const nodes = config.nodes;
+
+      for (const item in nodes) {
+        if (nodes.hasOwnProperty(item)) {
+          const node = nodes[item];
+          for (const name in controllers[index].nodes) {
+            if (controllers[index].nodes.hasOwnProperty(name)) {
+              const oldNode = controllers[index].nodes[name];
+              if (oldNode.isButton == node.isButton &&
+                  oldNode.index == node.index) {
+                if (item !== name) {
+                  renameNode(name, item, index);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  });
 }
 
 /**

--- a/src/create/controller/controller.js
+++ b/src/create/controller/controller.js
@@ -1,4 +1,5 @@
 const {Controller} = require('../../lib/controller');
+const fs = require('fs');
 const controllers = [];
 
 /**
@@ -57,6 +58,22 @@ function generateProgress(index, key) {
 }
 
 /**
+ * Generates a name input for a controller
+ * @param {Number} index The index of the controller
+ * @return {Node} The generated input
+ */
+function generateName(index) {
+  const name = document.createElement('input');
+  name.type = 'text';
+  name.id = `name-${index}`;
+  name.addEventListener('change', () => {
+    saveController(index);
+  });
+
+  return name;
+}
+
+/**
  * Generates a progress bar & input for every node in the controller
  * @param {Number} index The index of the controller
  */
@@ -64,6 +81,8 @@ function generateNodes(index) {
   const controller = controllers[index];
   const parent = document.createElement('div');
   parent.id = `controller-${index}`;
+  parent.appendChild(generateName(index));
+  parent.appendChild(document.createElement('br'));
   document.getElementById('controllers').appendChild(parent);
 
   for (const key in controller.nodes) {
@@ -148,6 +167,50 @@ function renameNode(oldName, newName, index) {
   delete nodes[oldName];
 
   controllers[index].updateNodes();
+}
+
+/**
+ * Generates the configuration of a given controller
+ * @param {Number} index The index of the controller
+ * @return {Object} The generated config
+ */
+function generateConfig(index) {
+  const controller = controllers[index];
+  const config = {};
+  config.id = controller.id;
+  config.index = controller.index;
+  config.nodes = {};
+
+  for (const key in controller.nodes) {
+    if (controller.nodes.hasOwnProperty(key)) {
+      const node = controller.nodes[key];
+      config.nodes[key] = {};
+      config.nodes[key].isButton = node.isButton;
+      config.nodes[key].index = node.index;
+      config.nodes[key].min = node.min;
+      config.nodes[key].max = node.max;
+    }
+  }
+
+  return config;
+}
+
+/**
+ * Saves a given controller's config
+ * @param {Number} index The index of the controller
+ */
+function saveController(index) {
+  const name = document.getElementById(`name-${index}`).value;
+  const config = JSON.stringify(generateConfig(index));
+
+  fs.writeFile(`./src/conf/Controllers/${name}.json`, config, (err) => {
+    if (err) {
+      console.error('Failed to write file! Do you have access?');
+      console.error(err);
+    } else {
+      console.log('Saved config successfully!');
+    }
+  });
 }
 
 // This should be migrated to animations for cleaner code

--- a/src/create/controller/controller.js
+++ b/src/create/controller/controller.js
@@ -132,7 +132,7 @@ function updateControllers() {
  * @return {Promise} A promise that resolves with true if config is found
  */
 function scanForConfig(id, index) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     const path = './src/conf/Controllers';
     const files = fs.readdirSync(path);
 

--- a/src/create/controller/controller.js
+++ b/src/create/controller/controller.js
@@ -1,6 +1,7 @@
 const {Controller} = require('../../lib/controller');
 const fs = require('fs');
 const controllers = [];
+const configs = {};
 
 /**
  * Updates the relevant progress bar when called via the 'change' event
@@ -118,6 +119,35 @@ function updateControllers() {
     for (const node in nodes) {
       if (nodes.hasOwnProperty(node)) {
         handleChange(index, node, nodes[node].value);
+      }
+    }
+    scanForConfig(controllers[index].id);
+  }
+}
+
+/**
+ * Scans the controller configuration directory for matching files
+ * @param {String} id The ID of the controller
+ */
+function scanForConfig(id) {
+  const path = './src/conf/Controllers';
+  const files = fs.readdirSync(path);
+
+  if (Object.entries(configs).length === 0) {
+    for (let i = 0; i < files.length; ++i) {
+      const data = fs.readFileSync(`${path}/${files[i]}`);
+      const config = JSON.parse(data.toString());
+      const name = files[i].split('.')[0];
+      configs[name] = {id: config.id};
+    }
+  }
+
+  for (const item in configs) {
+    if (configs.hasOwnProperty(item)) {
+      const config = configs[item];
+      if (config.id === id) {
+        loadController(item);
+        return;
       }
     }
   }
@@ -244,6 +274,8 @@ function loadController(name) {
           }
         }
       }
+
+      document.getElementById(`name-${index}`).value = name;
     }
   });
 }

--- a/src/create/controller/controller.js
+++ b/src/create/controller/controller.js
@@ -1,0 +1,59 @@
+const {Controller} = require('../../lib/controller');
+const controllers = [];
+
+/**
+ * Updates the listings of controllers
+ */
+function updateControllers() {
+  const parent = document.getElementById('parent');
+  for (let index = 0; index < 4; ++index) {
+    const nodes = controllers[index].nodes;
+    controllers[index].onchange = function(item, value) {
+      console.log(`${item}: ${value}`);
+    };
+    for (const node in nodes) {
+      if (nodes.hasOwnProperty(node)) {
+        controllers[index].updateNodes();
+      }
+    }
+  }
+}
+
+for (let i = 0; i < 4; ++i) {
+  controllers.push(new Controller('', i));
+  controllers[i].on('connect', () => {
+    console.log('Controller connected');
+    const gamepad = navigator.getGamepads()[i];
+    controllers[i].id = gamepad.id;
+    for (let axis = 0; axis < gamepad.axes.length; ++axis) {
+      controllers[i].addControllerNode(`Unnamed axis #${axis}`, false, axis, [0, 1]);
+    }
+    for (let button = 0; button < gamepad.buttons.length; ++button) {
+      controllers[i].addControllerNode(`Unnamed button #${button}`, true, button, [0, 1]);
+    }
+
+    controllers[i].updateNodes();
+    updateControllers();
+  });
+}
+
+/**
+ * Renames a node for a given controller
+ * @param {String} oldName The name of the node
+ * @param {String} newName The new name of the node
+ * @param {Number} index The index of the controller
+ */
+function renameNode(oldName, newName, index) {
+  const nodes = controllers[index].nodes;
+  Object.defineProperty(nodes, newName,
+    Object.getOwnPropertyDescriptor(nodes, oldName));
+  delete nodes[oldName];
+
+  controllers[index].updateNodes();
+}
+
+setInterval(() => {
+  for (let i = 0; i < 4; ++i) {
+    controllers[i].loop();
+  }
+}, 1);

--- a/src/create/controller/controller.js
+++ b/src/create/controller/controller.js
@@ -2,14 +2,55 @@ const {Controller} = require('../../lib/controller');
 const controllers = [];
 
 /**
+ * Updates the relevant progress bar when called via the 'change' event
+ * @param {Number} index The index of the controller
+ * @param {String} item The name of the node
+ * @param {Number} value The new value of the node
+ */
+function handleChange(index, item, value) {
+  if (document.getElementById(`controller-${index}`) == null) {
+    generateNodes(index);
+  }
+
+  const node = controllers[index].nodes[item];
+  const progress = document.getElementById(`${index}-${item}`);
+  progress.value = node.isButton? value : value + 1;
+}
+
+/**
+ * Generates a progress bar for every node in the controller
+ * @param {Number} index The index of the controller
+ */
+function generateNodes(index) {
+  const controller = controllers[index];
+  const parent = document.createElement('div');
+  parent.id = `controller-${index}`;
+  document.getElementById('controllers').appendChild(parent);
+
+  for (const key in controller.nodes) {
+    if (controller.nodes.hasOwnProperty(key)) {
+      const node = controller.nodes[key];
+      const progress = document.createElement('progress');
+      progress.id = `${controller.index}-${key}`;
+
+      progress.value = node.min;
+      progress.max = node.isButton? node.max : 2;
+      parent.appendChild(progress);
+      parent.appendChild(document.createElement('br'));
+
+      handleChange(index, key, node.value);
+    }
+  }
+}
+
+/**
  * Updates the listings of controllers
  */
 function updateControllers() {
-  const parent = document.getElementById('parent');
   for (let index = 0; index < 4; ++index) {
     const nodes = controllers[index].nodes;
-    controllers[index].onchange = function(item, value) {
-      console.log(`${item}: ${value}`);
+    controllers[index].onchange = (item, value) => {
+      handleChange(index, item, value);
     };
     for (const node in nodes) {
       if (nodes.hasOwnProperty(node)) {
@@ -19,21 +60,43 @@ function updateControllers() {
   }
 }
 
+/**
+ * Handles the connection of a controller
+ * @param {Number} index The index of the controller
+ */
+function handleConnect(index) {
+  console.log('Controller connected');
+  const gamepad = navigator.getGamepads()[index];
+  controllers[index].id = gamepad.id;
+  for (let axis = 0; axis < gamepad.axes.length; ++axis) {
+    controllers[index].addControllerNode(`Unnamed axis #${axis}`,
+        false, axis, [0, 1]);
+  }
+  for (let button = 0; button < gamepad.buttons.length; ++button) {
+    controllers[index].addControllerNode(`Unnamed button #${button}`,
+        true, button, [0, 1]);
+  }
+
+  controllers[index].updateNodes();
+  updateControllers();
+}
+
+/**
+ * Handles the disconnection of a controller
+ * @param {Number} index The index of the controller
+ */
+function handleDisconnect(index) {
+  console.log('Controller disconnected');
+  document.getElementById(`controller-${index}`).remove();
+}
+
 for (let i = 0; i < 4; ++i) {
   controllers.push(new Controller('', i));
   controllers[i].on('connect', () => {
-    console.log('Controller connected');
-    const gamepad = navigator.getGamepads()[i];
-    controllers[i].id = gamepad.id;
-    for (let axis = 0; axis < gamepad.axes.length; ++axis) {
-      controllers[i].addControllerNode(`Unnamed axis #${axis}`, false, axis, [0, 1]);
-    }
-    for (let button = 0; button < gamepad.buttons.length; ++button) {
-      controllers[i].addControllerNode(`Unnamed button #${button}`, true, button, [0, 1]);
-    }
-
-    controllers[i].updateNodes();
-    updateControllers();
+    return handleConnect(i);
+  });
+  controllers[i].on('disconnect', () => {
+    return handleDisconnect(i);
   });
 }
 
@@ -46,12 +109,13 @@ for (let i = 0; i < 4; ++i) {
 function renameNode(oldName, newName, index) {
   const nodes = controllers[index].nodes;
   Object.defineProperty(nodes, newName,
-    Object.getOwnPropertyDescriptor(nodes, oldName));
+      Object.getOwnPropertyDescriptor(nodes, oldName));
   delete nodes[oldName];
 
   controllers[index].updateNodes();
 }
 
+// This should be migrated to animations for cleaner code
 setInterval(() => {
   for (let i = 0; i < 4; ++i) {
     controllers[i].loop();

--- a/src/create/controller/controller.js
+++ b/src/create/controller/controller.js
@@ -18,7 +18,46 @@ function handleChange(index, item, value) {
 }
 
 /**
- * Generates a progress bar for every node in the controller
+ * Generates a label containing an input for a given node
+ * @param {Number} index The index of the controller
+ * @param {String} key The key of the specific controller node
+ * @return {Node} The generated label
+ */
+function generateLabel(index, key) {
+  const label = document.createElement('label');
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.value = key;
+  input.id = `${index}-${key}-input`;
+  input.addEventListener('change', (event) => {
+    const oldName = event.target.id.split('-')[1];
+    const newName = event.target.value;
+    renameNode(oldName, newName, index);
+    event.target.id = `${index}-${newName}-input`;
+  });
+
+  label.appendChild(input);
+  return label;
+}
+
+/**
+ * Generates a progress bar containing an input for a given node
+ * @param {Number} index The index of the controller
+ * @param {String} key The key of the specific controller node
+ * @return {Node} The generated label
+ */
+function generateProgress(index, key) {
+  const node = controllers[index].nodes[key];
+  const progress = document.createElement('progress');
+  progress.id = `${index}-${key}`;
+  progress.value = node.min;
+  progress.max = node.isButton? node.max : 2;
+
+  return progress;
+}
+
+/**
+ * Generates a progress bar & input for every node in the controller
  * @param {Number} index The index of the controller
  */
 function generateNodes(index) {
@@ -30,12 +69,8 @@ function generateNodes(index) {
   for (const key in controller.nodes) {
     if (controller.nodes.hasOwnProperty(key)) {
       const node = controller.nodes[key];
-      const progress = document.createElement('progress');
-      progress.id = `${controller.index}-${key}`;
-
-      progress.value = node.min;
-      progress.max = node.isButton? node.max : 2;
-      parent.appendChild(progress);
+      parent.appendChild(generateProgress(index, key));
+      parent.appendChild(generateLabel(index, key));
       parent.appendChild(document.createElement('br'));
 
       handleChange(index, key, node.value);

--- a/src/create/controller/controller.js
+++ b/src/create/controller/controller.js
@@ -182,7 +182,7 @@ function handleConnect(index) {
       }
       controllers[index].updateNodes();
     }
-    
+
     updateControllers();
   });
 }

--- a/src/create/controller/controller.js
+++ b/src/create/controller/controller.js
@@ -181,9 +181,8 @@ function handleConnect(index) {
         }
       }
       controllers[index].updateNodes();
-      generateNodes(index);
     }
-
+    
     updateControllers();
   });
 }
@@ -195,18 +194,29 @@ function handleConnect(index) {
 function handleDisconnect(index) {
   console.log('Controller disconnected');
   document.getElementById(`controller-${index}`).remove();
+  removeChildren(index);
+  resetController(index);
+}
+
+/**
+ * Resets a controller to default state
+ * @param {Number} index The index of the controller
+ */
+function resetController(index) {
+  controllers[index] = new Controller('', index);
+  controllers[index].saved = false;
+  controllers[index].saveLocation = null;
+  controllers[index].on('connect', () => {
+    return handleConnect(index);
+  });
+  controllers[index].on('disconnect', () => {
+    return handleDisconnect(index);
+  });
 }
 
 for (let i = 0; i < 4; ++i) {
-  controllers.push(new Controller('', i));
-  controllers[i].saved = false;
-  controllers[i].saveLocation = null;
-  controllers[i].on('connect', () => {
-    return handleConnect(i);
-  });
-  controllers[i].on('disconnect', () => {
-    return handleDisconnect(i);
-  });
+  controllers.push(null);
+  resetController(i);
 }
 
 /**
@@ -256,6 +266,21 @@ function generateConfig(index) {
 }
 
 /**
+ * Removes all children in a controller visualisation div
+ * @param {Number} index The index of the controller
+ */
+function removeChildren(index) {
+  const parent = document.getElementById(`controller-${index}`);
+  if (parent !== null) {
+    const children = parent.children;
+    for (let i = 0; i < children.length; ++i) {
+      const child = children[i];
+      parent.removeChild(child);
+    }
+  }
+}
+
+/**
  * Loads a compatible controller for editing
  * @param {String} name The name of the controller file
  * @param {Number} index The index of the controller
@@ -271,16 +296,7 @@ function loadController(name, index) {
       const nodes = config.nodes;
 
       controllers[index].nodes = {};
-      const parent = document.getElementById(`controller-${index}`);
-      if (parent !== null) {
-        const children = parent.children;
-        for (let i = 0; i < children.length; ++i) {
-          const child = children[i];
-          if (child.tagName !== 'INPUT') {
-            parent.removeChild(child);
-          }
-        }
-      }
+      removeChildren(index);
 
       for (const item in nodes) {
         if (nodes.hasOwnProperty(item)) {

--- a/src/create/controller/controller.js
+++ b/src/create/controller/controller.js
@@ -121,15 +121,16 @@ function updateControllers() {
         handleChange(index, node, nodes[node].value);
       }
     }
-    scanForConfig(controllers[index].id);
+    scanForConfig(controllers[index].id, index);
   }
 }
 
 /**
  * Scans the controller configuration directory for matching files
  * @param {String} id The ID of the controller
+ * @param {Number} index The index of the controller
  */
-function scanForConfig(id) {
+function scanForConfig(id, index) {
   const path = './src/conf/Controllers';
   const files = fs.readdirSync(path);
 
@@ -146,7 +147,7 @@ function scanForConfig(id) {
     if (configs.hasOwnProperty(item)) {
       const config = configs[item];
       if (config.id === id) {
-        loadController(item);
+        loadController(item, index);
         return;
       }
     }
@@ -246,8 +247,9 @@ function generateConfig(index) {
 /**
  * Loads a compatible controller for editing
  * @param {String} name The name of the controller file
+ * @param {Number} index The index of the controller
  */
-function loadController(name) {
+function loadController(name, index) {
   const path = `./src/conf/Controllers/${name}.json`;
   fs.readFile(path, (err, data) => {
     if (err) {
@@ -255,7 +257,6 @@ function loadController(name) {
       console.error(err);
     } else {
       const config = JSON.parse(data);
-      const index = config.index;
       const nodes = config.nodes;
 
       for (const item in nodes) {

--- a/src/lib/controller.js
+++ b/src/lib/controller.js
@@ -1,4 +1,5 @@
 const EventEmitter = require('events');
+const fs = require('fs');
 
 /**
  * A class representing a single button/axis on a controller
@@ -64,6 +65,17 @@ class Controller extends EventEmitter {
   }
 
   /**
+   * Loads a controller configuration file
+   * @param {String} name The name of the configuration file
+   */
+  loadConfig(name) {
+    const path = `./src/conf/${name}.json`;
+    fs.readFile(path, (err, data) => {
+      console.log(data);
+    });
+  }
+
+  /**
    * Adds a new controller node to the list of nodes
    * @param {String} name The name to give the input node
    * @param {Boolean} button If the node is a button or not
@@ -71,9 +83,21 @@ class Controller extends EventEmitter {
    * @param {Array} range The min & max range
    */
   addControllerNode(name, button, index, range) {
+    for (const node in this.nodes) {
+      if (this.nodes.hasOwnProperty(node)) {
+        const item = this.nodes[node];
+        if (item.index == index && item.isButton == button) {
+          console.warn(`Refusing to add node ${name} (duplicate)`);
+          return;
+        }
+      }
+    }
     this.nodes[name] = new ControllerInputNode(button, index, range);
   }
 
+  /**
+   * Updates the 'change' event listeners of every node
+   */
   updateNodes() {
     for (const item in this.nodes) {
       if (this.nodes.hasOwnProperty(item)) {

--- a/src/lib/controller.js
+++ b/src/lib/controller.js
@@ -57,6 +57,10 @@ class Controller extends EventEmitter {
     this.connected = false;
 
     this.nodes = {};
+
+    this.onchange = function(item, value) {
+      console.log(`${item}: ${value}`);
+    };
   }
 
   /**
@@ -68,6 +72,17 @@ class Controller extends EventEmitter {
    */
   addControllerNode(name, button, index, range) {
     this.nodes[name] = new ControllerInputNode(button, index, range);
+  }
+
+  updateNodes() {
+    for (const item in this.nodes) {
+      if (this.nodes.hasOwnProperty(item)) {
+        this.nodes[item].removeAllListeners('change');
+        this.nodes[item].on('change', (value) => {
+          this.onchange(item, value);
+        });
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
This pull request implements a visual controller creator. Users can connect controllers & remap the names of nodes so that it is clearer than numbered indices. This will come in handy when developing the profile creator, as the nodes will already have names that describe them. For example, A, B, X & Y could each represent their corresponding button on the gamepad, rather than numbered buttons.